### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#JD-Eclipse
+# JD-Eclipse
 
 JD-Eclipse, a Java decompiler plug-in for the Eclipse platform.
 
@@ -8,18 +8,18 @@ JD-Eclipse, a Java decompiler plug-in for the Eclipse platform.
 - Java Decompiler Wikipedia page: [http://en.wikipedia.org/wiki/Java_Decompiler](http://en.wikipedia.org/wiki/Java_Decompiler)
 - JD-Eclipse source code: [https://github.com/java-decompiler/jd-eclipse](https://github.com/java-decompiler/jd-eclipse)
 
-##Description
+## Description
 JD-Eclipse is a plug-in for the Eclipse platform. It allows you to 
 display all the Java sources during your debugging process, even if 
 you do not have them all.
 
-##How to build JD-Eclipse ?
-###With Gradle:
+## How to build JD-Eclipse ?
+### With Gradle:
 ```
 > ./gradlew installSiteDist
 ```
 generate _"build/install/jd-eclipse-site"_
-###With Eclipse:
+### With Eclipse:
 - Download dependencies
 ```
 > ./gradlew downloadDependencies
@@ -29,7 +29,7 @@ generate _"build/install/jd-eclipse-site"_
 - Export _"Deployable features"_,
 - Copy _"site.xml"_ to the destination directory.
 
-##How to install JD-Eclipse ?
+## How to install JD-Eclipse ?
 1. Build or download & unzip _"jd-eclipse-site-x.y.z.zip"_,
 2. Launch _Eclipse_,
 3. Click on _"Help > Install New Software..."_,
@@ -38,15 +38,15 @@ generate _"build/install/jd-eclipse-site"_
 6. Check _"Java Decompiler Eclipse Plug-in"_,
 7. Next, next, next... and restart.
 
-##How to check the file associations ?
+## How to check the file associations ?
 Click on _"Window > Preferences > General > Editors > File Associations"_
 - _"*.class"_ : _Eclipse_ _"Class File Viewer"_ is selected by default.
 - _"*.class without source"_ : _"JD Class File Viewer"_ is selected by default.
 
-##How to configure JD-Eclipse ?
+## How to configure JD-Eclipse ?
 Click on _"Window > Preferences > Java > Decompiler"_
 
-##How to uninstall JD-Eclipse ?
+## How to uninstall JD-Eclipse ?
 1. Click on _"Help > About Eclipse > Installation Details"_,
 2. Select _"JD-Eclipse Plug-in"_,
 3. Click on _"Uninstall..."_.


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
